### PR TITLE
feat: Add SSH key pair generation option

### DIFF
--- a/examples/private-cluster/main.tf
+++ b/examples/private-cluster/main.tf
@@ -7,8 +7,11 @@ module "free-k8s" {
 
   node_pool_size = 2
 
+  kubernetes_version          = "v1.26.2"
   control_plane_type          = "private"
   control_plane_allowed_cidrs = ["0.0.0.0/0"]
+
+  create_ssh_key_pair = true
 
   providers = {
     oci.home = oci.home

--- a/main.tf
+++ b/main.tf
@@ -8,9 +8,9 @@ module "oke" {
   home_region = var.home_region
 
   # ssh keys
-  ssh_private_key      = var.ssh_private_key
+  ssh_private_key      = var.create_ssh_key_pair ? chomp(local_file.ssh_private_key[0].content) : var.ssh_private_key
   ssh_private_key_path = var.ssh_private_key_path
-  ssh_public_key       = var.ssh_public_key
+  ssh_public_key       = var.create_ssh_key_pair ? chomp(local_file.ssh_public_key[0].content) : var.ssh_public_key
   ssh_public_key_path  = var.ssh_public_key_path
 
   # general oci parameters

--- a/tls_private_key.tf
+++ b/tls_private_key.tf
@@ -1,0 +1,19 @@
+resource "tls_private_key" "key" {
+  count = var.create_ssh_key_pair ? 1 : 0
+  algorithm = "RSA"
+  rsa_bits  = "4096"
+}
+
+resource "local_file" "ssh_private_key" {
+  count = var.create_ssh_key_pair ? 1 : 0
+  content         = tls_private_key.key[0].private_key_pem
+  filename        = "${abspath(path.root)}/id_rsa"
+  file_permission = "0600"
+}
+
+resource "local_file" "ssh_public_key" {
+  count = var.create_ssh_key_pair ? 1 : 0
+  content         = tls_private_key.key[0].public_key_openssh
+  filename        = "${abspath(path.root)}/id_rsa.pub"
+  file_permission = "0600"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -22,6 +22,12 @@ variable "tenancy_id" {
 }
 
 # ssh keys
+variable "create_ssh_key_pair" {
+  default     = false
+  description = "Whether to create an SSH key pair. If set to true, a new SSH key pair is created."
+  type        = bool
+}
+
 variable "ssh_private_key" {
   default     = ""
   description = "The contents of the private ssh key file, optionally base64-encoded."


### PR DESCRIPTION
This commit introduces the option to generate an SSH key pair using a Terraform configuration script. When the `create_ssh_key_pair` variable is set to true, a new SSH key pair is created by the `tls_private_key` resource and saved as local files `id_rsa` and `id_rsa.pub`.

For more information, see the documentation for the `tls_private_key` resource: https://www.terraform.io/docs/providers/tls/r/private_key.html