### PR TITLE
fix: Correct bug in handling public and private key file paths

### DIFF
--- a/modules/kubernetes/bastion-tennel.tf
+++ b/modules/kubernetes/bastion-tennel.tf
@@ -22,17 +22,34 @@ resource "null_resource" "bastion_tunnel" {
 }
 
 resource "local_file" "bastion_tunnel" {
-  content = templatefile("${path.module}/scripts/create_bastion_tunnel_template.sh",
+  depends_on = [local_file.id_rsa, local_file.id_rsa_pub]
+  content    = templatefile("${path.module}/scripts/create_bastion_tunnel_template.sh",
     {
       bastion_id       = var.control_plane_bastion_service_id
-      public_key_file  = local.ssh_authorized_keys
-      private_key_file = local.ssh_private_key
+      public_key_file  = local_file.id_rsa_pub[0].filename
+      private_key_file = local_file.id_rsa[0].filename
       cluster_ip       = local.private_endpoint_ip
       cluster_port     = local.private_endpoint_port
       region           = var.region
     }
   )
   filename = "${path.root}/cluster_access.sh"
+
+  count = local.post_provisioning_ops_enabled ? 1 : 0
+}
+
+resource "local_file" "id_rsa" {
+  content         = local.ssh_private_key
+  filename        = "${path.root}/id_rsa"
+  file_permission = "0600"
+
+  count = local.post_provisioning_ops_enabled ? 1 : 0
+}
+
+resource "local_file" "id_rsa_pub" {
+  content         = local.ssh_authorized_keys
+  filename        = "${path.root}/id_rsa.pub"
+  file_permission = "0600"
 
   count = local.post_provisioning_ops_enabled ? 1 : 0
 }

--- a/modules/kubernetes/scripts/create_bastion_tunnel_template.sh
+++ b/modules/kubernetes/scripts/create_bastion_tunnel_template.sh
@@ -70,4 +70,5 @@ nohup ssh -i "${private_key_file}" \
   -o PubkeyAcceptedAlgorithms=+ssh-rsa \
   -N -L 6443:"${cluster_ip}:${cluster_port}" \
   -p 22 \
+  -o StrictHostKeyChecking=no \
   "$session_id"@host.bastion."${region}".oci.oraclecloud.com >/dev/null 2>&1 &


### PR DESCRIPTION
- Pass file paths instead of file contents for public_key_file and private_key_file

This commit resolves a bug where the contents of public and private key files were incorrectly passed instead of the file paths in the public_key_file and private_key_file settings.